### PR TITLE
Initial implementation

### DIFF
--- a/lib/oauth2/jane.rb
+++ b/lib/oauth2/jane.rb
@@ -1,0 +1,1 @@
+require 'oauth2/jane/client'

--- a/lib/oauth2/jane/client.rb
+++ b/lib/oauth2/jane/client.rb
@@ -1,0 +1,30 @@
+# Modify OAuth2 Client to use json instead of form encoded post for token
+require 'json'
+
+module OAuth2
+  module Jane
+    class Client < ::OAuth2::Client
+        def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        params = Authenticator.new(id, secret, options[:auth_scheme]).apply(params)
+        opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}
+        headers = params.delete(:headers) || {}
+        if options[:token_method] == :post
+          # --------------- Change from original implementation ---------------
+          opts[:body] = JSON.generate params
+          opts[:headers] = {'Content-Type' => 'application/json'}
+          # --------------------------- Change end ----------------------------
+        else
+          opts[:params] = params
+          opts[:headers] = {}
+        end
+        opts[:headers].merge!(headers)
+        response = request(options[:token_method], token_url, opts)
+        if options[:raise_errors] && !(response.parsed.is_a?(Hash) && response.parsed['access_token'])
+          error = Error.new(response)
+          raise(error)
+        end
+        access_token_class.from_hash(self, response.parsed.merge(access_token_opts))
+      end
+    end
+  end
+end

--- a/lib/omniauth-jane.rb
+++ b/lib/omniauth-jane.rb
@@ -1,0 +1,3 @@
+require 'oauth2/jane'
+require "omniauth-jane/version"
+require 'omniauth/jane'

--- a/lib/omniauth-jane/version.rb
+++ b/lib/omniauth-jane/version.rb
@@ -1,0 +1,5 @@
+module OmniAuth
+  module Jane
+    VERSION = "1.0.0"
+  end
+end

--- a/lib/omniauth/jane.rb
+++ b/lib/omniauth/jane.rb
@@ -1,0 +1,1 @@
+require 'omniauth/strategies/jane'

--- a/lib/omniauth/strategies/jane.rb
+++ b/lib/omniauth/strategies/jane.rb
@@ -1,0 +1,38 @@
+require "omniauth/strategies/oauth2"
+require "json"
+require "http"
+require 'oauth2/response'
+
+module OmniAuth
+  module Strategies
+    class Jane < OmniAuth::Strategies::OAuth2
+      option :name, 'jane'
+      option :provider_ignores_state, true
+      option :site
+      option :client_options, {
+        token_url:     '/oauth/token',
+        authorize_url: '/oauth'
+      }
+
+      def token_params
+        params = super()
+        params.merge(parse: :json)
+      end
+
+      def client_options
+        @client_options ||= begin
+          site = options.site 
+          url_fixed_options = options.client_options.merge(
+            authorize_url: "#{site.sub('api.', '')}#{options.client_options[:authorize_url]}",
+            token_url: "#{site}/v1.0#{options.client_options[:token_url]}"
+          )
+          deep_symbolize(url_fixed_options)
+        end
+      end
+
+      def client
+        ::OAuth2::Jane::Client.new(options.client_id, options.client_secret, client_options)
+      end
+    end
+  end
+end

--- a/omniauth-jane.gemspec
+++ b/omniauth-jane.gemspec
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/omniauth-jane/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["ShippingEasy"]
+  gem.email         = ["dev@shippingeasy.com"]
+  gem.description   = "OmniAuth Strategy for Jane"
+  gem.summary       = "OmniAuth Strategy for Jane"
+  gem.homepage      = "https://github.com/ShippingEasy/omniauth-jane"
+
+  gem.files         = `git ls-files | grep -v example`.split($\)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.name          = "omniauth-jane"
+  gem.require_paths = ["lib"]
+  gem.version       = OmniAuth::Jane::VERSION
+
+  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.5'
+end


### PR DESCRIPTION
Quirks: Jane uses two different domains for the authorize_url and token_url, as well as requiring the body be JSON for the token request.

To handle the domain problem, I initialized the gem using "api.jane(test).com" and striped "api." when needed.

To handle the JSON body, I followed the method I used for a similar customization in the omniauth-wish gem and wrote a subclass of OAuth2::Client